### PR TITLE
feat: Flag generated feeds as private

### DIFF
--- a/pasjonsfrukt/main.py
+++ b/pasjonsfrukt/main.py
@@ -124,7 +124,7 @@ def build_feed(config: Config, episodes: list[podme_api.types.PodMeEpisode], slu
             link=feed_link
         ),
         items=sorted(items, key=lambda i: i.pubDate, reverse=True),
-        extensions=[iTunes()]
+        extensions=[iTunes(block='Yes')]
     )
     return feed.rss()
 


### PR DESCRIPTION
Mark the generated feeds as private towards third-party clients by utilizing the [`<block>` tag](https://learn.acast.com/en/articles/4619103-hiding-your-show-itunes-block-tags).