### PR TITLE
Change URL creation so no 307 redirect is needed

### DIFF
--- a/pasjonsfrukt/main.py
+++ b/pasjonsfrukt/main.py
@@ -108,7 +108,7 @@ def build_feed(config: Config, episodes: list[PodMeEpisode], slug: str, title: s
             description=e.description,
             guid=Guid(episode_id, isPermaLink=False),
             enclosure=Enclosure(
-                url=f'{config.host}/{episode_path}/{secret_query_param}',
+                url=f'{config.host}/{episode_path}{secret_query_param}',
                 type='audio/mpeg',
                 length=build_podcast_episode_file_path(config, slug, episode_id).stat().st_size
             ),
@@ -120,7 +120,7 @@ def build_feed(config: Config, episodes: list[PodMeEpisode], slug: str, title: s
                 )
             ]
         ))
-    feed_link = f"{config.host}/{slug}/{secret_query_param}"
+    feed_link = f"{config.host}/{slug}{secret_query_param}"
     feed = Feed(
         title=title,
         link=feed_link,


### PR DESCRIPTION
Changing creation of URL links so no 307 redirect is necessary. This is a issue when using the RSS feed in for example Audiobookshelf. When trying to download each episode each URL ends with "/" which is then redirected to  "" in the webserver. Example: `<enclosure url="https://domain.no/krimpodden-vg/4412499/"` will redirect to `<enclosure url="https://domain.no/krimpodden-vg/4412499"`. 
This will also be a issue if using a secret, since each URL will be `https://domain.no/krimpodden-vg/4412499/?secret=XXXXX` when the correct URL should be: `https://domain.no/krimpodden-vg/4412499?secret=XXXXX`